### PR TITLE
Handle missing WeasyPrint dependencies gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ An AI-powered story generator that creates **unlimited** custom picture books wi
 
 ## 🚀 **Quick Start**
 
+### **Option 0: Automated local deployment helper**
+
+```bash
+./deploy_local.sh
+```
+
+This script follows the same steps documented below—installing dependencies with `uv sync`, creating a `.env` file from the template if needed, and reminding you to add your `GOOGLE_API_KEY`. After it completes you can launch the UI with `uv run gemini-picturebook` or use the CLI entry points described later in this section.
+
 ### **Option 1: Claude Desktop Integration (Recommended)**
 
 1. **Install the package:**
@@ -81,6 +89,20 @@ uv run gemini-picturebook
 ```bash
 uv run python -m gemini_picturebook_generator.enhanced_story_generator
 ```
+
+### **Optional: Enable PDF export (WeasyPrint system libraries)**
+WeasyPrint needs native libraries for font rendering. If you only plan to download HTML, you can skip this step—PDF generation will simply be disabled with a warning. To enable PDF exports:
+
+- **macOS (Homebrew):**
+  ```bash
+  brew install cairo pango gdk-pixbuf libffi
+  ```
+- **Ubuntu/Debian:**
+  ```bash
+  sudo apt-get install libcairo2 libpango-1.0-0 libgdk-pixbuf2.0-0 libffi-dev
+  ```
+
+After installing the system packages, run `uv pip install weasyprint` (or `uv sync`) again so the Python bindings can link against them.
 
 ## 🤖 **Claude Desktop MCP Integration**
 

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Helper script to follow the README deployment steps locally
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$PROJECT_ROOT"
+
+echo "🎨 Deploying Gemini Picture Book Generator locally"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "❌ uv is not installed. Please install uv (https://github.com/astral-sh/uv) and re-run this script."
+  exit 1
+fi
+
+# Install dependencies using uv
+if ! uv sync; then
+  echo "⚠️  uv sync failed. Please ensure you have network connectivity and try again."
+  exit 1
+fi
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp .env.template .env
+  echo "ℹ️  Created .env from template. Please edit .env and add your GOOGLE_API_KEY before running the app."
+else
+  if grep -q "your_google_api_key_here" .env; then
+    echo "⚠️  Update the GOOGLE_API_KEY value in .env with your actual API key from https://aistudio.google.com/app/apikey."
+  fi
+fi
+
+echo "✅ Dependencies installed."
+echo "🚀 To launch the web UI run: uv run gemini-picturebook"
+echo "📟 To run the CLI generator run: uv run python -m gemini_picturebook_generator.enhanced_story_generator"

--- a/enhanced_pdf_generator.py
+++ b/enhanced_pdf_generator.py
@@ -16,10 +16,12 @@ from datetime import datetime
 try:
     from weasyprint import HTML, CSS
     WEASYPRINT_AVAILABLE = True
-except ImportError:
+    WEASYPRINT_IMPORT_ERROR = None
+except (ImportError, OSError) as weasyprint_error:
     HTML = None
     CSS = None
     WEASYPRINT_AVAILABLE = False
+    WEASYPRINT_IMPORT_ERROR = weasyprint_error
 
 
 def create_print_optimized_html(story_data, output_dir):
@@ -377,8 +379,10 @@ def create_enhanced_pdf(story_data, output_dir):
         str: Path to PDF file or None if failed
     """
     if not WEASYPRINT_AVAILABLE:
-        print("⚠️  WeasyPrint not available. PDF generation skipped.")
-        print("   Install with: pip install weasyprint")
+        print("⚠️  WeasyPrint system libraries are missing, so PDF generation is skipped.")
+        print("   Install the OS dependencies listed in the README, then run: uv pip install weasyprint")
+        if WEASYPRINT_IMPORT_ERROR is not None:
+            print(f"   Import error: {WEASYPRINT_IMPORT_ERROR}")
         return None
 
     try:

--- a/enhanced_story_generator.py
+++ b/enhanced_story_generator.py
@@ -25,8 +25,12 @@ from PIL import Image
 try:
     from weasyprint import CSS, HTML
     WEASYPRINT_AVAILABLE = True
-except ImportError:
+    WEASYPRINT_IMPORT_ERROR = None
+except (ImportError, OSError) as weasyprint_error:
+    CSS = None
+    HTML = None
     WEASYPRINT_AVAILABLE = False
+    WEASYPRINT_IMPORT_ERROR = weasyprint_error
 
 
 def setup_client():
@@ -422,12 +426,11 @@ def create_pdf_from_html(html_path, output_dir):
         str: Path to PDF file or None if failed
     """
     if not WEASYPRINT_AVAILABLE:
-        print("⚠️  WeasyPrint not available. PDF generation skipped.")
-        print("   Install with: uv pip install weasyprint")
+        print("⚠️  WeasyPrint system libraries are missing, so PDF generation is skipped.")
+        print("   Install the OS dependencies listed in the README, then run: uv pip install weasyprint")
+        if WEASYPRINT_IMPORT_ERROR is not None:
+            print(f"   Import error: {WEASYPRINT_IMPORT_ERROR}")
         return None
-
-    # Import here to avoid unbound variable error
-    from weasyprint import CSS, HTML
 
     try:
         html_file = Path(html_path)

--- a/gemini_picturebook_generator/enhanced_story_generator.py
+++ b/gemini_picturebook_generator/enhanced_story_generator.py
@@ -25,8 +25,12 @@ from PIL import Image
 try:
     from weasyprint import CSS, HTML
     WEASYPRINT_AVAILABLE = True
-except ImportError:
+    WEASYPRINT_IMPORT_ERROR = None
+except (ImportError, OSError) as weasyprint_error:
+    CSS = None
+    HTML = None
     WEASYPRINT_AVAILABLE = False
+    WEASYPRINT_IMPORT_ERROR = weasyprint_error
 
 
 def setup_client():
@@ -422,12 +426,11 @@ def create_pdf_from_html(html_path, output_dir):
         str: Path to PDF file or None if failed
     """
     if not WEASYPRINT_AVAILABLE:
-        print("⚠️  WeasyPrint not available. PDF generation skipped.")
-        print("   Install with: uv pip install weasyprint")
+        print("⚠️  WeasyPrint system libraries are missing, so PDF generation is skipped.")
+        print("   Install the OS dependencies listed in the README, then run: uv pip install weasyprint")
+        if WEASYPRINT_IMPORT_ERROR is not None:
+            print(f"   Import error: {WEASYPRINT_IMPORT_ERROR}")
         return None
-
-    # Import here to avoid unbound variable error
-    from weasyprint import CSS, HTML
 
     try:
         html_file = Path(html_path)


### PR DESCRIPTION
## Summary
- guard the WeasyPrint import so the CLI still starts when native libraries are unavailable
- surface a clear warning that PDF export is disabled and why, including the original import error
- document the OS packages required to enable WeasyPrint-backed PDF generation

## Testing
- python - <<'PY'"import importlib\nmod = importlib.import_module('gemini_picturebook_generator.enhanced_story_generator')\nprint('Imported module. WEASYPRINT_AVAILABLE=', mod.WEASYPRINT_AVAILABLE)\nprint('Import error type:', type(mod.WEASYPRINT_IMPORT_ERROR).__name__ if mod.WEASYPRINT_IMPORT_ERROR else None)\nPY"

------
https://chatgpt.com/codex/tasks/task_e_68d8210692f4832ba4d6339af26ab024